### PR TITLE
RenameSuggestion

### DIFF
--- a/publications-rest/src/main/java/scot/gov/publications/hippo/DocumentHelper.java
+++ b/publications-rest/src/main/java/scot/gov/publications/hippo/DocumentHelper.java
@@ -42,6 +42,6 @@ public class DocumentHelper {
             documentManager.depublishDocument(path);
         }
 
-        nodeFactory.ensureEmbargoAndWorkflowJobs(node, metadata.getPublicationDateWithTimezone(), metadata.shoudlEmbargo());
+        nodeFactory.ensureEmbargoAndWorkflowJobs(node, metadata.getPublicationDateWithTimezone(), metadata.shouldEmbargo());
     }
 }

--- a/publications-rest/src/main/java/scot/gov/publications/hippo/DocumentUploader.java
+++ b/publications-rest/src/main/java/scot/gov/publications/hippo/DocumentUploader.java
@@ -112,7 +112,7 @@ public class DocumentUploader {
                 title,
                 "govscot:DocumentInformation",
                 metadata.getPublicationDateWithTimezone(),
-                metadata.shoudlEmbargo());
+                metadata.shouldEmbargo());
         documentInfoNode.setProperty(GOVSCOT_TITLE, title);
         documentInfoNode.setProperty("govscot:accessible", false);
         documentInfoNode.setProperty("govscot:highlighted", false);

--- a/publications-rest/src/main/java/scot/gov/publications/metadata/Metadata.java
+++ b/publications-rest/src/main/java/scot/gov/publications/metadata/Metadata.java
@@ -278,7 +278,7 @@ public class Metadata {
         return typeMapper.map(publicationType);
     }
 
-    public boolean shoudlEmbargo() {
+    public boolean shouldEmbargo() {
 
         // we never need to embargo a publications whose publication date is in the past
         if (publicationDate.isBefore(LocalDateTime.now())) {


### PR DESCRIPTION
### Renaming Suggestion of Method Names to Make Them More Descriptive
---
**Description**
---

We have developed a tool (**NameSpotter**) for identifying non-descriptive method names, and using this tool we find a non-descriptive method name in your repository:
```java
/* Non-descriptive Method Name in publications-rest/src/main/java/scot/gov/publications/metadata/Metadata.java */
    public boolean shoudlEmbargo() {

        // we never need to embargo a publications whose publication date is in the past
        if (publicationDate.isBefore(LocalDateTime.now())) {
            return false;
        }

        // if the sensitive flag is set or if this is an embargo type then we should embargo it.
        return isSensitive() || typeMapper.isEmbargoType(publicationType);
    }
```
We considered "shoudlEmbargo" as non-descriptive because it contains typo, i.e., "shoudl" -> "should". We have corrected it and submitted a pull request.



Do you agree with the judgment? 

- If not, could you please leave your valuable opinion?

- If you do agree, the relevant modification has been submitted as a PR, and thanks for your precious time to consider it.